### PR TITLE
⚡ Performance optimization for drift calculation

### DIFF
--- a/tas_dna_pilot.py
+++ b/tas_dna_pilot.py
@@ -38,9 +38,13 @@ class ERTriagePilot:
             return 0.0
 
         # TVD = 0.5 * sum(|P(x) - Q(x)|)
+        # Optimized: Pre-calculate the inverse of total_patients to replace
+        # division with multiplication inside the loop.
+        inv_total = 1.0 / self.total_patients
         l1_distance = 0.0
+        counts = self.current_counts
         for category, baseline_prob in self.baseline.items():
-            current_prob = self.current_counts.get(category, 0) / self.total_patients
+            current_prob = counts.get(category, 0) * inv_total
             l1_distance += abs(current_prob - baseline_prob)
 
         return 0.5 * l1_distance


### PR DESCRIPTION
Optimized `calculate_drift` in `tas_dna_pilot.py` by pre-calculating the inverse of `total_patients` and localizing attribute lookups. Verified with unit tests.

---
*PR created automatically by Jules for task [6503214389166440971](https://jules.google.com/task/6503214389166440971) started by @TrueAlpha-spiral*