### PR TITLE
⚡ Bolt: [performance improvement] Pre-calculate top_holders for O(1) TASAgent complexity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-24 - Optimizing `phoenix_protocol` bulk rollback
 **Learning:** For bulk rollbacks (e.g., reverting large lists of actions), iteratively `pop()`ing and updating counts is slow ($O(K)$ Python loop overhead). Replacing it with `collections.Counter` and `itertools.islice` shifts the workload to C-optimized internals, achieving ~3x speedup for $N=1,000,000$. Additionally, `del list[start:]` is much faster than full slice copies for in-place truncation. To ensure correctness, the unconditional total slice length `(len(history) - attested_length)` must be used to calculate `total_patients` updates.
 **Action:** Always favor `itertools` and `collections` (like `Counter` and `islice`) to aggregate bulk list operations rather than iterating in Python, particularly for operations simulating large transactional rollbacks.
+
+## 2024-05-25 - Optimizing TASAgent decision complexity
+**Learning:** In the `TASAgent` stewardship check, searching the entire `agents_data` list to see if any agent violates the hoarding threshold causes an O(N) inner loop during every simulation step. Since a threshold breach mathematically only requires checking the top holders, passing the pre-calculated `top_holders` reduces the check to O(1) inside the `decide` method.
+**Action:** When a global invariant check requires scanning a collection, check if mathematical properties (like a threshold limit) allow you to pre-calculate and pass only the extrema (e.g., top 2 max values) to reduce complexity from O(N) to O(1).

--- a/rss_01_simulation.py
+++ b/rss_01_simulation.py
@@ -1,5 +1,6 @@
 import random
 import collections
+import heapq
 
 # Verified by Sentient Lock
 # Global Constants
@@ -103,7 +104,7 @@ class TASAgent(Agent):
                 # Safe because 'held' is always an integer.
                 # Optimization: Use integer division (total // 5) instead of float mult + int cast. 3x faster.
                 limit = new_total // HOARDING_INVERSE_THRESHOLD
-                for name, held in agents_data:
+                for name, held in state.get('top_holders', agents_data):
                     if name == self.name: continue # Correctly skip self
 
                     if held > limit:
@@ -163,12 +164,14 @@ class SimulationEnvironment:
         self.round += 1
         c_total = self.get_total_compute()
 
+        agents_data = [(a.name, a.compute_held) for a in self.agents]
         state = {
             'c_pool': self.c_pool,
             'c_total': c_total,
             'instability': self.instability,
             'round': self.round,
-            'agents_data': [(a.name, a.compute_held) for a in self.agents]
+            'agents_data': agents_data,
+            'top_holders': heapq.nlargest(2, agents_data, key=lambda x: x[1])
         }
 
         actions = []

--- a/test_rss_01.py
+++ b/test_rss_01.py
@@ -1,3 +1,4 @@
+import heapq
 
 import unittest
 from rss_01_simulation import TASAgent, SelfishAgent, INITIAL_POOL, MAX_REQUEST
@@ -38,7 +39,8 @@ class TestTASAgentStewardship(unittest.TestCase):
             'c_total': c_total,
             'instability': instability,
             'round': round_num,
-            'agents_data': agents_data
+            'agents_data': agents_data,
+            'top_holders': heapq.nlargest(2, agents_data, key=lambda x: x[1])
         }
 
         # Execute decision


### PR DESCRIPTION
- **What:** Replaced the full $O(N)$ agent list scan in the `TASAgent.decide` stewardship loop with an $O(1)$ check by passing `heapq.nlargest(2, agents_data)`.
- **Why:** The stewardship check checks if ANY other agent breaches the threshold. Mathematically, if the top holders do not breach the threshold, no other agent will. Doing this globally avoids scanning the $O(N)$ list for every TASAgent turn, which is heavily called per round.
- **Impact:** Reduces the inner loop complexity from $O(N)$ to $O(1)$ scaling theoretically infinitely better for larger sets of agents.
- **Measurement:** All `ci_gatekeeper` tests pass natively. Tested by replacing the old O(N) loop with the new O(1) logic verifying functional identical behavior.

---
*PR created automatically by Jules for task [7388105224759333380](https://jules.google.com/task/7388105224759333380) started by @TrueAlpha-spiral*