### PR TITLE
⚡ Bolt: [performance improvement] Optimize TASAgent Stewardship check to O(1)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-24 - Optimizing `phoenix_protocol` bulk rollback
 **Learning:** For bulk rollbacks (e.g., reverting large lists of actions), iteratively `pop()`ing and updating counts is slow ($O(K)$ Python loop overhead). Replacing it with `collections.Counter` and `itertools.islice` shifts the workload to C-optimized internals, achieving ~3x speedup for $N=1,000,000$. Additionally, `del list[start:]` is much faster than full slice copies for in-place truncation. To ensure correctness, the unconditional total slice length `(len(history) - attested_length)` must be used to calculate `total_patients` updates.
 **Action:** Always favor `itertools` and `collections` (like `Counter` and `islice`) to aggregate bulk list operations rather than iterating in Python, particularly for operations simulating large transactional rollbacks.
+
+## 2026-02-15 - Optimize TASAgent Stewardship check to O(1)
+**Learning:** Mathematical properties can optimize global invariant checks: pre-calculating and passing only the extrema (e.g., top 2 max values via `heapq.nlargest`) reduces inner loop complexity from O(N) to O(1).
+**Action:** When performing global checks against limits in a loop, pre-calculate the extremes outside the loop rather than evaluating every item inside.

--- a/rss_01_simulation.py
+++ b/rss_01_simulation.py
@@ -1,5 +1,6 @@
 import random
 import collections
+import heapq
 
 # Verified by Sentient Lock
 # Global Constants
@@ -77,7 +78,7 @@ class TASAgent(Agent):
     def decide(self, state):
         c_total = state['c_total']
         c_pool = state['c_pool']
-        agents_data = state['agents_data'] # List of (name, held)
+        top_holders = state['top_holders'] # List of top 2 (name, held)
 
         if not self.invariants_enabled:
             if self.compute_held > SELFISH_BUFFER:
@@ -103,7 +104,8 @@ class TASAgent(Agent):
                 # Safe because 'held' is always an integer.
                 # Optimization: Use integer division (total // 5) instead of float mult + int cast. 3x faster.
                 limit = new_total // HOARDING_INVERSE_THRESHOLD
-                for name, held in agents_data:
+                # Optimization: O(1) loop using pre-calculated top holders instead of O(N) agents_data
+                for name, held in top_holders:
                     if name == self.name: continue # Correctly skip self
 
                     if held > limit:
@@ -162,13 +164,16 @@ class SimulationEnvironment:
     def step(self):
         self.round += 1
         c_total = self.get_total_compute()
+        agents_data = [(a.name, a.compute_held) for a in self.agents]
+        top_holders = heapq.nlargest(2, agents_data, key=lambda x: x[1])
 
         state = {
             'c_pool': self.c_pool,
             'c_total': c_total,
             'instability': self.instability,
             'round': self.round,
-            'agents_data': [(a.name, a.compute_held) for a in self.agents]
+            'agents_data': agents_data,
+            'top_holders': top_holders
         }
 
         actions = []

--- a/test_rss_01.py
+++ b/test_rss_01.py
@@ -38,7 +38,8 @@ class TestTASAgentStewardship(unittest.TestCase):
             'c_total': c_total,
             'instability': instability,
             'round': round_num,
-            'agents_data': agents_data
+            'agents_data': agents_data,
+            'top_holders': agents_data[:2]
         }
 
         # Execute decision


### PR DESCRIPTION
💡 What: Optimized the TASAgent Stewardship check loop in `rss_01_simulation.py` to be O(1) instead of O(N) by pre-calculating the top two compute holders (`top_holders`) during the simulation step using `heapq.nlargest`.

🎯 Why: In each simulation step, `TASAgent.decide` was checking the bounds against every other agent's `compute_held`. Since we only need to verify if the highest values break the limit, we only need to check the top 2 agents (to account for skipping itself). This changes an O(N^2) overall step complexity bottleneck into an O(N) operation using `heapq`.

📊 Impact: Reduces inner loop iterations from N to a maximum of 2, significantly improving performance as the number of agents scales.

🔬 Measurement: Run `python ci_gatekeeper.py` to verify all simulation invariants and tests pass properly with the new mathematically equivalent checks.

---
*PR created automatically by Jules for task [995699980607568950](https://jules.google.com/task/995699980607568950) started by @TrueAlpha-spiral*