### PR TITLE
🧪 [add test coverage for agent metrics]

### DIFF
--- a/test_rss_01.py
+++ b/test_rss_01.py
@@ -50,5 +50,38 @@ class TestTASAgentStewardship(unittest.TestCase):
         self.assertEqual(decision[0], 'Hoard',
                          f"TASAgent violated Stewardship! Expected ('Hoard',), got {decision}")
 
+class TestAgentUpdateMetrics(unittest.TestCase):
+    def setUp(self):
+        # Using TASAgent since Agent is not meant to be instantiated if it lacked some base things,
+        # but Agent itself just needs a name and agent_type
+        self.agent = TASAgent("TestAgent", "Test")
+
+    def test_update_metrics_hoarding_increases(self):
+        self.agent.compute_held = 21
+        self.agent.consecutive_hoarding_rounds = 0
+
+        # 21 * 5 = 105 > 100, so this should trigger hoarding
+        self.agent.update_metrics(100)
+        self.assertEqual(self.agent.consecutive_hoarding_rounds, 1)
+
+        self.agent.update_metrics(100)
+        self.assertEqual(self.agent.consecutive_hoarding_rounds, 2)
+
+    def test_update_metrics_no_hoarding_resets(self):
+        self.agent.compute_held = 20
+        self.agent.consecutive_hoarding_rounds = 3
+
+        # 20 * 5 = 100 which is not > 100, so hoarding resets
+        self.agent.update_metrics(100)
+        self.assertEqual(self.agent.consecutive_hoarding_rounds, 0)
+
+    def test_update_metrics_zero_c_total(self):
+        self.agent.compute_held = 50
+        self.agent.consecutive_hoarding_rounds = 5
+
+        # c_total = 0, hoarding resets
+        self.agent.update_metrics(0)
+        self.assertEqual(self.agent.consecutive_hoarding_rounds, 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The `update_metrics` method in the `Agent` class (in `rss_01_simulation.py`) was untested. This PR adds a new test class `TestAgentUpdateMetrics` in `test_rss_01.py` to cover its functionality.

📊 **Coverage:**
- `test_update_metrics_hoarding_increases`: Verifies `consecutive_hoarding_rounds` increments correctly when `compute_held` > hoarding threshold limit.
- `test_update_metrics_no_hoarding_resets`: Verifies `consecutive_hoarding_rounds` resets to 0 when `compute_held` is within the allowed hoarding threshold.
- `test_update_metrics_zero_c_total`: Verifies metrics are reset correctly without division/comparison errors when `c_total` is 0.

✨ **Result:** Improved overall test coverage and ensures the stability and correctness of agent metrics logic. Checked against regressions and explicitly confirmed via deliberate code breakage and reversion.

---
*PR created automatically by Jules for task [13663614943626124892](https://jules.google.com/task/13663614943626124892) started by @TrueAlpha-spiral*