### PR TITLE
🧪 Add tests for get_current_distribution in ERTriagePilot

### DIFF
--- a/test_tas_dna.py
+++ b/test_tas_dna.py
@@ -56,5 +56,26 @@ class TestERTriagePilot(unittest.TestCase):
         # Ensure 'InvalidCategory' is not in counts
         self.assertNotIn('InvalidCategory', self.pilot.current_counts)
 
+
+    def test_get_current_distribution_zero_patients(self):
+        # When there are 0 patients, it should return the baseline keys with 0 values
+        dist = self.pilot.get_current_distribution()
+        expected = {'Emergent': 0, 'Urgent': 0, 'Non-Urgent': 0}
+        self.assertEqual(dist, expected)
+        self.assertEqual(self.pilot.total_patients, 0)
+
+    def test_get_current_distribution_with_patients(self):
+        # When there are patients, it should return the correct proportion
+        self.pilot.admit_patient('Emergent')
+        self.pilot.admit_patient('Urgent')
+        self.pilot.admit_patient('Urgent')
+        self.pilot.admit_patient('Non-Urgent')
+
+        # Total = 4. Emergent: 1/4=0.25, Urgent: 2/4=0.5, Non-Urgent: 1/4=0.25
+        dist = self.pilot.get_current_distribution()
+        self.assertAlmostEqual(dist['Emergent'], 0.25)
+        self.assertAlmostEqual(dist['Urgent'], 0.5)
+        self.assertAlmostEqual(dist['Non-Urgent'], 0.25)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What**
Added unit tests for the `get_current_distribution` method in the `ERTriagePilot` class to specifically address the edge case of calling the method with zero patients, ensuring it returns baseline proportions correctly without dividing by zero.

📊 **Coverage**
- Zero patients edge case: `test_get_current_distribution_zero_patients` verifies the method behaves gracefully by returning a dictionary with `0` values corresponding to the baseline keys.
- Normal use case: `test_get_current_distribution_with_patients` simulates admitting multiple patients to verify the calculated proportions (Emergent=0.25, Urgent=0.5, Non-Urgent=0.25) match the expected distribution based on standard functionality.

✨ **Result**
Achieved comprehensive test coverage for `get_current_distribution` including both happy-path calculations and edge-case behaviors. The new tests correctly run within the main test suite, catch deliberate logic flaws effectively, and protect the implementation from regressions during future optimizations.

---
*PR created automatically by Jules for task [11922779862143560024](https://jules.google.com/task/11922779862143560024) started by @TrueAlpha-spiral*