### PR TITLE
🧪 [testing improvement] Add test coverage for airlock resonance boundary condition

### DIFF
--- a/tests/test_airlock.py
+++ b/tests/test_airlock.py
@@ -13,5 +13,11 @@ class TestAirlock(unittest.TestCase):
         self.assertEqual(status, AIRLOCK_DENIED_ENERGY_COST_TOO_HIGH)
         self.assertGreater(cost, 5.0)
 
+    def test_airlock_gate_high_resonance(self):
+        # Test boundary condition for resonance > 709.0 (math.exp limit)
+        status, cost = airlock_gate(0.5, 710.0)
+        self.assertEqual(status, AIRLOCK_DENIED_ENERGY_COST_TOO_HIGH)
+        self.assertEqual(cost, float('inf'))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The `airlock_gate` function in `tas_core/alpha/airlock.py` had an untested edge case for high values of `resonance` (`resonance > 709.0`) where the cost defaults to `float('inf')` to bypass an expensive exponential math call and prevent `OverflowError`. This branch lacked explicit test coverage.

📊 **Coverage:** A new test case `test_airlock_gate_high_resonance` was added to `tests/test_airlock.py` specifically targeting this boundary condition, calling the function with `resonance = 710.0` and confirming the returned cost is `float('inf')` and the status evaluates to `AIRLOCK_DENIED_ENERGY_COST_TOO_HIGH`.

✨ **Result:** Test coverage improved, ensuring future refactoring won't accidentally break this important edge case and optimization within the physics of truth simulated by the airlock gate.

---
*PR created automatically by Jules for task [1926172000335358057](https://jules.google.com/task/1926172000335358057) started by @TrueAlpha-spiral*