### PR TITLE
🧪 [testing improvement] Add test for zero patients to calculate_drift

### DIFF
--- a/test_tas_dna.py
+++ b/test_tas_dna.py
@@ -56,5 +56,11 @@ class TestERTriagePilot(unittest.TestCase):
         # Ensure 'InvalidCategory' is not in counts
         self.assertNotIn('InvalidCategory', self.pilot.current_counts)
 
+    def test_calculate_drift_zero_patients(self):
+        # Test calculating drift when there are zero patients
+        # Just calling it immediately after init should return 0.0
+        drift = self.pilot.calculate_drift()
+        self.assertAlmostEqual(drift, 0.0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing edge case for `calculate_drift` with zero patients in `tas_dna_pilot.py`.

📊 **Coverage:** What scenarios are now tested
The `calculate_drift` method has a guard clause `if self.total_patients == 0: return 0.0`. This PR adds a test case that initializes the `ERTriagePilot` and immediately calls `calculate_drift` without admitting any patients. 

✨ **Result:** The improvement in test coverage
By adding this edge case, we ensure that if this guard clause is removed, the program catches the `ZeroDivisionError` instead of throwing it at runtime.

---
*PR created automatically by Jules for task [9512195201697831388](https://jules.google.com/task/9512195201697831388) started by @TrueAlpha-spiral*