### PR TITLE
🔒 Prevent energy cost bypass via NaN input

### DIFF
--- a/tas_core/alpha/airlock.py
+++ b/tas_core/alpha/airlock.py
@@ -27,7 +27,7 @@ def airlock_gate(coherence, resonance):
     else:
         cost = (1.0 - coherence) * math.exp(resonance)
 
-    if cost > MAX_ENERGY_COST:
+    if math.isnan(cost) or cost > MAX_ENERGY_COST:
         return AIRLOCK_DENIED_ENERGY_COST_TOO_HIGH, cost
 
     return AIRLOCK_PASSED, cost


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in `airlock_gate` where `NaN` values for the calculated `energy cost` could bypass the `MAX_ENERGY_COST` threshold check.

⚠️ **Risk:** Attackers providing `NaN` via malformed `coherence` or `resonance` inputs could execute ideas that should be denied due to high energy cost, potentially leading to system instability or resource exhaustion.

🛡️ **Solution:** Added an explicit `math.isnan(cost)` check in the airlock's security gate. Since `NaN > 5.0` evaluates to `False` in Python, this ensures that undefined cost values are correctly treated as security violations and denied.

---
*PR created automatically by Jules for task [9515506563247996676](https://jules.google.com/task/9515506563247996676) started by @TrueAlpha-spiral*